### PR TITLE
Only show DGU orgs

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -3,7 +3,7 @@ class OrganisationsController < ApplicationController
   respond_to :json
 
   def index
-    query = params[:q].to_s
+    query = params[:q].to_s.gsub(" ", "-")
 
     @organisations = Organisation.dgu.where("name LIKE (?)", "%#{query.downcase}%")
     respond_with @organisations

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -4,7 +4,8 @@ class OrganisationsController < ApplicationController
 
   def index
     query = params[:q].to_s
-    @organisations = Organisation.where("name LIKE (?)", "%#{query.downcase}%")
+
+    @organisations = Organisation.dgu.where("name LIKE (?)", "%#{query.downcase}%")
     respond_with @organisations
   end
 

--- a/lib/tasks/organisations.rake
+++ b/lib/tasks/organisations.rake
@@ -6,16 +6,17 @@ namespace :organisations do
   task :weekly_import => :environment do
     if Time.now.monday?
       Rake::Task["organisations:import"].execute
-    end    
+    end
   end
-  
+
   desc "Imports organisations from the data.gov.uk hierarchy"
   task :import => :environment do
-    response = Net::HTTP.get_response("data.gov.uk","/api/action/group_tree?type=organization")
+    uri = URI("https://data.gov.uk/api/action/group_tree?type=organization")
+    response = Net::HTTP.get_response(uri)
     json = JSON.parse(response.body)
     results = json['result']
     puts "#{results.length} top level organisations found"
     OrganisationImporter.populate(results)
   end
-  
+
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -26,4 +26,15 @@ describe OrganisationsController do
     expect(results.first["text"]).to eq("My Fantastic Organisation")
   end
 
+  it "replaces spaces with dashes" do
+    FactoryGirl.create(:organisation, name: "my-fantastic-organisation", title: "My Fantastic Organisation")
+
+    get "index", q: "my fant", format: "json"
+
+    results = JSON.parse(response.body)
+
+    expect(results.count).to eq(1)
+    expect(results.first["text"]).to eq("My Fantastic Organisation")
+  end
+
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -13,4 +13,17 @@ describe OrganisationsController do
     expect(results.count).to eq(1)
     expect(results.first["text"]).to eq("My Fantastic Organisation")
   end
+
+  it "should be limited to DGU organisations" do
+    FactoryGirl.create(:organisation, name: "my-fantastic-organisation", title: "My Fantastic Organisation")
+    FactoryGirl.create(:organisation, name: "another-fantastic-organisation", title: "Another Fantastic Organisation", dgu_id: nil)
+
+    get "index", q: "fantastic", format: "json"
+
+    results = JSON.parse(response.body)
+
+    expect(results.count).to eq(1)
+    expect(results.first["text"]).to eq("My Fantastic Organisation")
+  end
+
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -2,4 +2,15 @@ require 'spec_helper'
 
 describe OrganisationsController do
 
+  it "should query an organisation by title" do
+    FactoryGirl.create(:organisation, name: "my-terrrible-organisation", title: "My Terrible Organisation")
+    FactoryGirl.create(:organisation, name: "my-fantastic-organisation", title: "My Fantastic Organisation")
+
+    get "index", q: "fantastic", format: "json"
+
+    results = JSON.parse(response.body)
+
+    expect(results.count).to eq(1)
+    expect(results.first["text"]).to eq("My Fantastic Organisation")
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -2,8 +2,18 @@ require 'spec_helper'
 
 describe Organisation do
 
+  describe "self.dgu" do
+    it "should only return dgu Organisations" do
+      FactoryGirl.create(:organisation, title: "Non-DGU organisation", dgu_id: nil)
+      FactoryGirl.create(:organisation, title: "DGU orginisation", dgu_id: 123)
+
+      expect(Organisation.dgu.count).to eq(1)
+      expect(Organisation.dgu.first.title).to eq("DGU orginisation")
+    end
+  end
+
   describe "#set_name" do
-    it "should set a name slug on create" do 
+    it "should set a name slug on create" do
       o = Organisation.new
       o.title = "Department of Stuff"
       o.save


### PR DESCRIPTION
Fixes #285

Also fixed the broken orgnisation import (DGU now redirects to https), added a few tests, and now replace spaces with `-`, so searches can match full organisation names

<!---
@huboard:{"order":216.75,"milestone_order":287,"custom_state":""}
-->
