### PR TITLE
Styling tidyup

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -92,3 +92,35 @@ background-image: linear-gradient(to bottom, #e65d00, #e65d00);
   position:relative;
   top:1px;
 }
+
+.btn.red {
+  color: #ffffff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #da4f49;
+  background-image: -moz-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#bd362f));
+  background-image: -webkit-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: -o-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: linear-gradient(to bottom, #ee5f5b, #bd362f);
+  background-repeat: repeat-x;
+  border-color: #bd362f #bd362f #802420;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b', endColorstr='#ffbd362f', GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
+}
+
+.btn.red:hover {
+  color: #fff;
+  background-image: -moz-linear-gradient(top, #ee5f5b, #ee5f5b);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#ee5f5b));
+  background-image: -webkit-linear-gradient(top, #ee5f5b, #ee5f5b);
+  background-image: -o-linear-gradient(top, #ee5f5b, #ee5f5b);
+  background-image: linear-gradient(to bottom, #ee5f5b, #ee5f5b);
+    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ee5f5b', endColorstr='#ee5f5b');
+    background-color:#ee5f5b;
+}
+
+.btn.red:active {
+  position:relative;
+  top:1px;
+}

--- a/app/assets/stylesheets/my_assessments.scss
+++ b/app/assets/stylesheets/my_assessments.scss
@@ -2,11 +2,11 @@
 
 .small { font-size: 0.7em; }
 
-#notes-form input[type="text"], 
+#notes-form input[type="text"],
 #title-form input[type="text"] {
   font-size: inherit;
   width:100%;
-  display: inline-block;  
+  display: inline-block;
   margin:0;
 }
 
@@ -40,7 +40,7 @@ ul#myAssessments {
   display: table;
   background: $pathwayLightGrey;
   font-size: 14px;
-  
+
   &.current {background: white;
 
    .details { color: black !important;}
@@ -80,7 +80,7 @@ ul#myAssessments {
 
    &.actions {
     text-align: center;
-    a.delete {color: $odiRed; margin-top: 0.5em; display: block;}
+    a.btn.red { margin-top: 1.5em; }
    }
 
    &:last-child {border-right: none;}
@@ -91,24 +91,24 @@ ul#myAssessments {
 }
 
 //ASSESSMENT PAGE
-#progress-bar { 
-  width: 280px; background-color:silver; 
+#progress-bar {
+  width: 280px; background-color:silver;
   background: none repeat scroll 0% 0% #F5F5F5;
   border: 1px solid #DDD;
   border-radius: 10px;
-  overflow: hidden; 
+  overflow: hidden;
   margin-top:2px;
 }
 #progress-bar div { background: none repeat scroll 0% 0% #FF6700; height:0.7em; }
 
 div.highlight-dimension { border-top: 1px solid #DDD; }
-div.highlight-dimension:nth-child(even) { 
+div.highlight-dimension:nth-child(even) {
   padding-top:5px; padding-bottom:5px;
   background: none repeat scroll 0% 0% #F5F5F5;
 }
 
-div.assessment-overview { 
-  h5 { font-weight:normal; font-size:1em; margin-top: 11px; } 
+div.assessment-overview {
+  h5 { font-weight:normal; font-size:1em; margin-top: 11px; }
   a.btn { width:70%; float:right; }
   div.activity { padding: 5px 0px; border-bottom: 1px solid white; margin-top:3px; }
   div.activity.complete { color:#0DBC37; }

--- a/app/assets/stylesheets/question.scss
+++ b/app/assets/stylesheets/question.scss
@@ -68,10 +68,14 @@
 }
 
 div.nested_object {
-  
+
   fieldset { margin: 1em; margin-right: 0em; }
   a.delete_association { float:right; }
   label { display: inline-block; width: 10%; }
   input.form-control { width: 69%; display: inline-block; margin-bottom:0.5em; }
 
+}
+
+.alert {
+  margin: 1em 0;
 }

--- a/app/views/assessments/_assessment_summary.html.erb
+++ b/app/views/assessments/_assessment_summary.html.erb
@@ -16,10 +16,10 @@
        <%= content_tag :h2, "Start a new assessment", class: "assessmentTitle" %>
      <% else %>
        <%= content_tag :h2, assessment.title, class: "assessmentTitle" %>
-  
-       <span class="started glyphicon glyphicon-calendar" aria-hidden="true"></span> 
+
+       <span class="started glyphicon glyphicon-calendar" aria-hidden="true"></span>
        <%= content_tag :span, "Started: #{pretty_date(assessment.start_date)}" %>
-       
+
        <span class="updated glyphicon glyphicon-calendar" aria-hidden="true"></span>
        <% if current %>
         <%= content_tag :span, "Last updated: #{pretty_date(assessment.updated_at)}" %>
@@ -33,18 +33,18 @@
     <% if assessment.blank? %>
       <%= link_to begin_assessment_path, class: "btn green" do %>
       Start assessment <span class="glyphicon glyphicon-chevron-right"></span>
-      <% end %> 
+      <% end %>
     <% else %>
           <% if current %>
             <%= link_to assessment_path(assessment), class: "btn green", role: "button" do %>
-              Continue assessment &raquo; 
+              Continue assessment &raquo;
             <% end %>
           <% else %>
             <%= link_to report_path(assessment), class: "btn btn-default", role: "button" do %>
-              View assessment &raquo; 
+              View assessment &raquo;
             <% end %>
           <% end %>
-          <%= link_to assessment_path(assessment), method: :delete, data: { confirm: "Are you sure?" }, class: "delete" do %>
+          <%= link_to assessment_path(assessment), method: :delete, data: { confirm: "Are you sure?" }, class: "btn red" do %>
               Delete this assessment <span class="glyphicon glyphicon-remove-sign" aria-hidden="true"></span>
           <% end %>
     <% end %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,6 +1,6 @@
 <% if object.errors.any? %>
-<div class = "error-messages">
-  <p>The following problems were found: </p>
+<div class="alert alert-danger error-messages">
+  <h4>The following problems were found: </h4>
   <ul>
     <% object.errors.full_messages.each do |msg| %>
       <li><%= msg %></li>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require File.expand_path('../application', __FILE__)
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+  html_tag.html_safe
+end


### PR DESCRIPTION
I've fixed #173 by making the delete button more obvious, as well as spacing it out more, like so:

![delete](https://cloud.githubusercontent.com/assets/109774/10308464/c9f29f96-6c2d-11e5-97e7-ce97de23e780.png)

I've also fixed #118 by making the error messages stand out a bit more (using the default Bootstrap `alert`):

![alert](https://cloud.githubusercontent.com/assets/109774/10308556/594fa044-6c2e-11e5-9605-a22d1179d8c2.png)



I also noticed that the Rails default `field_with_errors` div was screwing with the formatting, so I've done away with that too.