### PR TITLE
Remove beta and status altogether

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,7 +12,7 @@
 
         <h1 class="site-title">
           <a href="/"><%= title %></a>
-          <span class="label label-success status"><%= status.upcase %></span>
+          <span class="label label-success status"></span>
         </h1>
 
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
   <body class="odi-blue">
     
-    <%= render partial: 'layouts/header', :locals => { :title => t(:site_title), :status => "beta" } %>
+    <%= render partial: 'layouts/header', :locals => { :title => t(:site_title) } %>
     
     <div id='wrapper'>
       <% if content_for?(:header) %>


### PR DESCRIPTION
Adhering to convention where only alpha and beta need to be overtly
indicated as such. Kept this as simple as possible